### PR TITLE
[PAGOPA-1841] feat: refactored queries in order to include intermediate steps

### DIFF
--- a/src/main/java/it/gov/pagopa/wispconverter/technicalsupport/repository/ReEventRepository.java
+++ b/src/main/java/it/gov/pagopa/wispconverter/technicalsupport/repository/ReEventRepository.java
@@ -8,25 +8,81 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Set;
 
 @Repository
 public interface ReEventRepository extends CosmosRepository<ReEventEntity, String> {
 
-    @Query("select * from c where c.partitionKey >= @dateFrom and c.partitionKey <= @dateTo and c.domainId = @organizationId and c.noticeNumber = @noticeNumber")
-    List<ReEventEntity> findByIdDominioAndNoticeNumber(@Param("dateFrom") String dateFrom,
-                                                       @Param("dateTo") String dateTo,
-                                                       @Param("organizationId") String organizationId,
-                                                       @Param("noticeNumber") String noticeNumber);
-
-    @Query("select * from c where c.partitionKey >= @dateFrom and c.partitionKey <= @dateTo and c.domainId = @organizationId and c.iuv = @iuv")
-    List<ReEventEntity> findByIdDominioAndIuv(@Param("dateFrom") String dateFrom,
-                                              @Param("dateTo") String dateTo,
-                                              @Param("organizationId") String organizationId,
-                                              @Param("iuv") String iuv);
 
     @Query("select * from c where c.partitionKey >= @dateFrom and c.partitionKey <= @dateTo and c.operationId = @operationId")
     List<ReEventEntity> findByOperationId(@Param("dateFrom") String dateFrom,
                                           @Param("dateTo") String dateTo,
                                           @Param("operationId") String operationId);
 
+
+    @Query("SELECT DISTINCT VALUE c.sessionId " +
+            "FROM c " +
+            "WHERE (c.partitionKey >= @dateFrom AND c.partitionKey <= @dateTo) " +
+            "AND c.iuv = @iuv " +
+            "AND c.domainId = @organizationId " +
+            "AND IS_DEFINED(c.sessionId) AND c.sessionId != null")
+    Set<String> findSessionIdByIuvAndDomainId(@Param("dateFrom") String dateFrom,
+                                              @Param("dateTo") String dateTo,
+                                              @Param("organizationId") String organizationId,
+                                              @Param("iuv") String iuv);
+
+    @Query("SELECT DISTINCT VALUE c.sessionId " +
+            "FROM c " +
+            "WHERE (c.partitionKey >= @dateFrom AND c.partitionKey <= @dateTo) " +
+            "AND c.noticeNumber = @noticeNumber " +
+            "AND c.domainId = @organizationId " +
+            "AND IS_DEFINED(c.sessionId) AND c.sessionId != null")
+    Set<String> findSessionIdByNoticeNumberAndDomainId(@Param("dateFrom") String dateFrom,
+                                                       @Param("dateTo") String dateTo,
+                                                       @Param("organizationId") String organizationId,
+                                                       @Param("noticeNumber") String noticeNumber);
+
+    @Query("SELECT DISTINCT VALUE c.noticeNumber " +
+            "FROM c " +
+            "WHERE (c.partitionKey >= @dateFrom AND c.partitionKey <= @dateTo) " +
+            "AND ARRAY_CONTAINS(@sessionIds, c.sessionId) " +
+            "AND IS_DEFINED(c.noticeNumber) AND c.noticeNumber != null")
+    Set<String> findNoticeNumberBySessionId(@Param("dateFrom") String dateFrom,
+                                            @Param("dateTo") String dateTo,
+                                            @Param("sessionIds") Set<String> sessionId);
+
+    @Query("SELECT DISTINCT VALUE c.paymentToken " +
+            "FROM c " +
+            "WHERE (c.partitionKey >= @dateFrom AND c.partitionKey <= @dateTo) " +
+            "AND ARRAY_CONTAINS(@noticeNumbers, c.noticeNumber) " +
+            "AND c.domainId = @organizationId " +
+            "AND IS_DEFINED(c.paymentToken) AND c.paymentToken != null")
+    Set<String> findPaymentTokenByNoticeNumber(@Param("dateFrom") String dateFrom,
+                                               @Param("dateTo") String dateTo,
+                                               @Param("organizationId") String organizationId,
+                                               @Param("noticeNumbers") Set<String> noticeNumbers);
+
+    @Query("SELECT DISTINCT VALUE c.operationId " +
+            "FROM c " +
+            "WHERE (c.partitionKey >= @dateFrom AND c.partitionKey <= @dateTo) " +
+            "AND (ARRAY_CONTAINS(@sessionIds, c.sessionId) " +
+            "OR ((ARRAY_CONTAINS(@noticeNumbers, c.noticeNumber) AND c.domainId = @organizationId) OR ARRAY_CONTAINS(@paymentTokens, c.paymentToken))) " +
+            "AND IS_DEFINED(c.operationId) AND c.operationId != null")
+    Set<String> findOperationIdByFoundData(@Param("dateFrom") String dateFrom,
+                                           @Param("dateTo") String dateTo,
+                                           @Param("organizationId") String organizationId,
+                                           @Param("sessionIds") Set<String> sessionIds,
+                                           @Param("noticeNumbers") Set<String> noticeNumbers,
+                                           @Param("paymentTokens") Set<String> paymentTokens);
+
+    @Query("SELECT * " +
+            "FROM c " +
+            "WHERE (c.partitionKey >= @dateFrom AND c.partitionKey <= @dateTo) " +
+            "AND ARRAY_CONTAINS(@operationIds, c.operationId) " +
+            "OR ARRAY_CONTAINS(@sessionIds, c.sessionId) " +
+            "ORDER BY c._ts ASC")
+    List<ReEventEntity> findByOperationIdAndSessionId(@Param("dateFrom") String dateFrom,
+                                                      @Param("dateTo") String dateTo,
+                                                      @Param("operationIds") Set<String> operationIds,
+                                                      @Param("sessionIds") Set<String> sessionIds);
 }

--- a/src/main/java/it/gov/pagopa/wispconverter/technicalsupport/service/mapper/ReEventMapper.java
+++ b/src/main/java/it/gov/pagopa/wispconverter/technicalsupport/service/mapper/ReEventMapper.java
@@ -2,17 +2,25 @@ package it.gov.pagopa.wispconverter.technicalsupport.service.mapper;
 
 import it.gov.pagopa.wispconverter.technicalsupport.repository.model.ReEventEntity;
 import it.gov.pagopa.wispconverter.technicalsupport.service.model.ReEventDto;
+import it.gov.pagopa.wispconverter.technicalsupport.util.Constants;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
 
 import java.util.List;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
-public interface ReEventMapper {
+public abstract class ReEventMapper {
 
+    @Mapping(target = "httpHeaders", expression = "java(obfuscateSecrets(reEventEntity.getHttpHeaders()))")
+    public abstract ReEventDto toReEventDto(ReEventEntity reEventEntity);
 
-    ReEventDto toReEventDto(ReEventEntity reEventEntity);
-    List<ReEventDto> toReEventDtoList(List<ReEventEntity> reEventEntity);
+    public abstract List<ReEventDto> toReEventDtoList(List<ReEventEntity> reEventEntity);
 
-
+    public String obfuscateSecrets(String httpHeaders) {
+        if (httpHeaders != null) {
+            httpHeaders = httpHeaders.replaceAll(Constants.SUBSCRIPTION_KEY_PATTERN, "\"Ocp-Apim-Subscription-Key\": [***]");
+        }
+        return httpHeaders;
+    }
 }

--- a/src/main/java/it/gov/pagopa/wispconverter/technicalsupport/util/Constants.java
+++ b/src/main/java/it/gov/pagopa/wispconverter/technicalsupport/util/Constants.java
@@ -17,5 +17,7 @@ public class Constants {
     public static final String DATE_FROM = "dateFrom";
     public static final String DATE_TO = "dateTo";
 
+    public static final String SUBSCRIPTION_KEY_PATTERN = "\"?Ocp-Apim-Subscription-Key\"?: ?\\[(\\S+ ?\\S+|\\S+, \\S+)]";
+
 
 }

--- a/src/test/java/it/gov/pagopa/wispconverter/technicalsupport/TechnicalSupportControllerTest.java
+++ b/src/test/java/it/gov/pagopa/wispconverter/technicalsupport/TechnicalSupportControllerTest.java
@@ -102,7 +102,7 @@ class TechnicalSupportControllerTest {
                 .iuv(iuv)
                 .build());
 
-        Mockito.when(reEventRepository.findByIdDominioAndIuv(any(), any(), any(), any())).thenReturn(reEventEntityList);
+        Mockito.when(reEventRepository.findByOperationIdAndSessionId(any(), any(), any(), any())).thenReturn(reEventEntityList);
 
         String url = String.format("http://localhost:%s/organizations/%s/iuv/%s?dateFrom=%s&dateTo=%s",
                 port,
@@ -118,7 +118,7 @@ class TechnicalSupportControllerTest {
         assertNotNull(reEventResponse);
         assertThat(reEventResponse.getCount()).isEqualTo(1);
         assertThat(reEventResponse.getData()).hasSize(1);
-        assertThat(reEventResponse.getData().get(0).getOrganizationId()).isEqualTo(organizationId);
+        assertThat(reEventResponse.getData().get(0).getDomainId()).isEqualTo(organizationId);
         assertThat(reEventResponse.getData().get(0).getIuv()).isEqualTo(iuv);
     }
 
@@ -135,7 +135,7 @@ class TechnicalSupportControllerTest {
                 .domainId(organizationId)
                 .noticeNumber(noticeNumber)
                 .build());
-        Mockito.when(reEventRepository.findByIdDominioAndNoticeNumber(any(), any(), any(), any())).thenReturn(reEventEntityList);
+        Mockito.when(reEventRepository.findByOperationIdAndSessionId(any(), any(), any(), any())).thenReturn(reEventEntityList);
 
         String url = String.format("http://localhost:%s/organizations/%s/notice-number/%s?dateFrom=%s&dateTo=%s",
                 port,
@@ -151,7 +151,7 @@ class TechnicalSupportControllerTest {
         assertNotNull(reEventResponse);
         assertThat(reEventResponse.getCount()).isEqualTo(1);
         assertThat(reEventResponse.getData()).hasSize(1);
-        assertThat(reEventResponse.getData().get(0).getOrganizationId()).isEqualTo(organizationId);
+        assertThat(reEventResponse.getData().get(0).getDomainId()).isEqualTo(organizationId);
         assertThat(reEventResponse.getData().get(0).getNoticeNumber()).isEqualTo(noticeNumber);
     }
 


### PR DESCRIPTION
The Technical Support APIs are a valid tool for describe events in monitoring situation. For WISP dismantling, this tool was not correctly tuned because this flow provide an high number of intermediate steps that describe the payment process in a detailed way. The previous APIs in WISP dismantling's Technical Support does not provide all the steps that were required for a detailed monitoring.  
This PR contains a whole refactoring of those API. In particular, the starting query is converted into a larger set of queries that take all the necessary information from RE and returns a final batch of events with all the intermediate steps.  
Also, this PR contains the conversion logic that provide the `Ocp-Apim-Subscription-Key` header logged in RE events to be obfuscated and secured.

#### List of Changes
 - refactored queries for `find-by-notice-number` API
 - refactored queries for `find-by-iuv` API
 - defined obfuscation logic on subscription-key in headers

#### Motivation and Context
This change is required for better perform monitoring on WISP dismantling process

#### How Has This Been Tested?
 - Tested in local environment
 - Tested in UAT environment

#### Screenshots (if appropriate):

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
