### PR TITLE
feat: add new API for retrieve receipt status

### DIFF
--- a/.identity/00_data.tf
+++ b/.identity/00_data.tf
@@ -36,9 +36,9 @@ data "azurerm_key_vault_secret" "key_vault_sonar" {
   key_vault_id = data.azurerm_key_vault.key_vault.id
 }
 
-data "azurerm_key_vault_secret" "key_vault_bot_token" {
-  name         = "bot-token-github"
-  key_vault_id = data.azurerm_key_vault.key_vault.id
+data "azurerm_key_vault_secret" "key_vault_bot_cd_token" {
+  name         = "pagopa-platform-domain-github-bot-cd-pat"
+  key_vault_id = data.azurerm_key_vault.domain_key_vault.id
 }
 
 data "azurerm_key_vault_secret" "key_vault_cucumber_token" {

--- a/.identity/03_github_environment.tf
+++ b/.identity/03_github_environment.tf
@@ -35,7 +35,7 @@ locals {
   }
   repo_secrets = {
     "SONAR_TOKEN" : data.azurerm_key_vault_secret.key_vault_sonar.value,
-    "BOT_TOKEN_GITHUB" : data.azurerm_key_vault_secret.key_vault_bot_token.value,
+    "BOT_TOKEN_GITHUB" : data.azurerm_key_vault_secret.key_vault_bot_cd_token.value,
     "CUCUMBER_PUBLISH_TOKEN" : data.azurerm_key_vault_secret.key_vault_cucumber_token.value,
     "SUBKEY" : data.azurerm_key_vault_secret.key_vault_integration_test_subkey.value,
   }

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -45,7 +45,7 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/ReceiptsStatusSnapshotResponse"
+                  "$ref" : "#/components/schemas/PendingReceiptsResponse"
                 }
               }
             },
@@ -122,6 +122,52 @@
           "type" : "string"
         }
       } ]
+    },
+    "/enhanced/monitoring/receipts/status" : {
+      "parameters" : [ {
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "in" : "header",
+        "name" : "X-Request-Id",
+        "schema" : {
+          "type" : "string"
+        }
+      } ],
+      "post" : {
+        "description" : "Retrieve the status of a list of receipts that could have been sent to creditor institution",
+        "operationId" : "extractReceiptsStatus",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/ReceiptsStatusFilterRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ReceiptsStatusResponse"
+                }
+              }
+            },
+            "description" : "Successfully extracted data",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          }
+        },
+        "summary" : "Get receipts status",
+        "tags" : [ "Technical Support - Enhanced features" ]
+      }
     },
     "/enhanced/organizations/{organizationId}/iuv/{iuv}/details" : {
       "parameters" : [ {
@@ -982,6 +1028,26 @@
         },
         "description" : "The payment identification information related to the payment analyzed in the flow"
       },
+      "PendingReceipt" : {
+        "type" : "object",
+        "properties" : {
+          "payment" : {
+            "$ref" : "#/components/schemas/PaymentIdentifier"
+          },
+          "receipt_content" : {
+            "type" : "string",
+            "description" : "The content of the receipt that can be sent to creditor institution if required",
+            "example" : "eyJjb250ZW50IjoiPC4uLj4ifQ=="
+          },
+          "receipt_to_send" : {
+            "type" : "string",
+            "description" : "The type of receipt to be send if required",
+            "example" : "OK",
+            "enum" : [ "OK", "KO" ]
+          }
+        },
+        "description" : "The list of payments on which there is a pending receipt"
+      },
       "PendingReceiptsFilterRequest" : {
         "required" : [ "creditor_institution", "lower_bound_date", "upper_bound_date" ],
         "type" : "object",
@@ -1009,6 +1075,18 @@
             "type" : "string",
             "description" : "The upper limit of the date slot in 'Europe/Rome' timezone, used as delimiter for the search time (in yyyy-MM-ddThh:mm:ss)",
             "format" : "date-time"
+          }
+        }
+      },
+      "PendingReceiptsResponse" : {
+        "type" : "object",
+        "properties" : {
+          "pending_receipts" : {
+            "type" : "array",
+            "description" : "The list of payments on which there is a pending receipt",
+            "items" : {
+              "$ref" : "#/components/schemas/PendingReceipt"
+            }
           }
         }
       },
@@ -1182,6 +1260,98 @@
             "items" : {
               "$ref" : "#/components/schemas/ReEvent"
             }
+          }
+        }
+      },
+      "ReceiptsStatus" : {
+        "type" : "object",
+        "properties" : {
+          "ccp" : {
+            "type" : "string",
+            "description" : "The payment context code (aka CCP) of the payment tentative",
+            "example" : "001924757343397669-00001"
+          },
+          "domain_id" : {
+            "type" : "string",
+            "description" : "The identifier of the creditor institution",
+            "example" : "012345678901"
+          },
+          "iuv" : {
+            "type" : "string",
+            "description" : "The IUV code of the payment",
+            "example" : "001924757343397669"
+          },
+          "last_update" : {
+            "type" : "string",
+            "description" : "The datetime of the last update made on the receipt",
+            "format" : "date-time"
+          },
+          "status" : {
+            "type" : "string",
+            "description" : "The sending status of the receipt",
+            "example" : "SENT"
+          },
+          "type" : {
+            "type" : "string",
+            "description" : "The type of the receipt (OK or KO)",
+            "example" : "KO"
+          }
+        },
+        "description" : "The receipts classified by their status, extracted in the temporal snapshot"
+      },
+      "ReceiptsStatusFilterRequest" : {
+        "required" : [ "creditor_institution", "lower_bound_date", "upper_bound_date" ],
+        "type" : "object",
+        "properties" : {
+          "creditor_institution" : {
+            "type" : "string",
+            "description" : "The identifier of the creditor institution",
+            "example" : "12345678901"
+          },
+          "iuvs" : {
+            "uniqueItems" : true,
+            "type" : "array",
+            "description" : "The list of IUV payment codes to be used as a search filter. They can be null if a search on whole creditor institution is required",
+            "items" : {
+              "type" : "string",
+              "description" : "The list of IUV payment codes to be used as a search filter. They can be null if a search on whole creditor institution is required"
+            }
+          },
+          "lower_bound_date" : {
+            "type" : "string",
+            "description" : "The lower limit of the date slot in 'Europe/Rome' timezone, used as delimiter for the search time (in yyyy-MM-ddThh:mm:ss)",
+            "format" : "date-time"
+          },
+          "show_in_sent_status" : {
+            "type" : "boolean",
+            "description" : "The flag that permits to exclude the receipts in 'SENT' status"
+          },
+          "upper_bound_date" : {
+            "type" : "string",
+            "description" : "The upper limit of the date slot in 'Europe/Rome' timezone, used as delimiter for the search time (in yyyy-MM-ddThh:mm:ss)",
+            "format" : "date-time"
+          }
+        }
+      },
+      "ReceiptsStatusResponse" : {
+        "type" : "object",
+        "properties" : {
+          "lower_bound_date" : {
+            "type" : "string",
+            "description" : "The lower limit of the date slot in 'Europe/Rome' timezone, used as delimiter for the search time (in yyyy-MM-ddThh:mm:ss)",
+            "format" : "date-time"
+          },
+          "receipts" : {
+            "type" : "array",
+            "description" : "The receipts classified by their status, extracted in the temporal snapshot",
+            "items" : {
+              "$ref" : "#/components/schemas/ReceiptsStatus"
+            }
+          },
+          "upper_bound_date" : {
+            "type" : "string",
+            "description" : "The upper limit of the date slot in 'Europe/Rome' timezone, used as delimiter for the search time (in yyyy-MM-ddThh:mm:ss)",
+            "format" : "date-time"
           }
         }
       },

--- a/src/main/java/it/gov/pagopa/wispconverter/technicalsupport/controller/TechnicalSupportEnhancedController.java
+++ b/src/main/java/it/gov/pagopa/wispconverter/technicalsupport/controller/TechnicalSupportEnhancedController.java
@@ -148,7 +148,7 @@ public class TechnicalSupportEnhancedController {
 
     @Operation(summary = "Get pending receipts", description = "Retrieve the list of pending receipt that could have not been sent to creditor institution", tags = {"Technical Support - Enhanced features"})
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Successfully extracted data", content = @Content(schema = @Schema(implementation = ReceiptsStatusSnapshotResponse.class)))
+            @ApiResponse(responseCode = "200", description = "Successfully extracted data", content = @Content(schema = @Schema(implementation = PendingReceiptsResponse.class)))
     })
     @PostMapping(value = "/monitoring/receipts/pending", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
     public PendingReceiptsResponse extractPendingReceipts(@RequestBody @io.swagger.v3.oas.annotations.parameters.RequestBody PendingReceiptsFilterRequest request) {
@@ -156,6 +156,21 @@ public class TechnicalSupportEnhancedController {
         List<PendingReceipt> pendingReceipts = enhancedFeaturesService.extractPendingReceipts(request);
         return PendingReceiptsResponse.builder()
                 .pendingReceipts(pendingReceipts)
+                .build();
+    }
+
+    @Operation(summary = "Get receipts status", description = "Retrieve the status of a list of receipts that could have been sent to creditor institution", tags = {"Technical Support - Enhanced features"})
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully extracted data", content = @Content(schema = @Schema(implementation = ReceiptsStatusResponse.class)))
+    })
+    @PostMapping(value = "/monitoring/receipts/status", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ReceiptsStatusResponse extractReceiptsStatus(@RequestBody @io.swagger.v3.oas.annotations.parameters.RequestBody ReceiptsStatusFilterRequest request) {
+
+        List<ReceiptsStatus> receiptsStatus = enhancedFeaturesService.extractReceiptsStatus(request);
+        return ReceiptsStatusResponse.builder()
+                .receipts(receiptsStatus)
+                .lowerBoundDate(request.getLowerBoundDate())
+                .upperBoundDate(request.getUpperBoundDate())
                 .build();
     }
 }

--- a/src/main/java/it/gov/pagopa/wispconverter/technicalsupport/controller/model/experimental/monitoring/ReceiptsStatus.java
+++ b/src/main/java/it/gov/pagopa/wispconverter/technicalsupport/controller/model/experimental/monitoring/ReceiptsStatus.java
@@ -1,0 +1,41 @@
+package it.gov.pagopa.wispconverter.technicalsupport.controller.model.experimental.monitoring;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.time.Instant;
+
+@Builder
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ReceiptsStatus {
+
+    @Schema(example = "012345678901", description = "The identifier of the creditor institution")
+    @JsonProperty("domain_id")
+    private String domainId;
+
+    @Schema(example = "001924757343397669", description = "The IUV code of the payment")
+    @JsonProperty("iuv")
+    private String iuv;
+
+    @Schema(example = "001924757343397669-00001", description = "The payment context code (aka CCP) of the payment tentative")
+    @JsonProperty("ccp")
+    private String ccp;
+
+    @Schema(example = "KO", description = "The type of the receipt (OK or KO)")
+    @JsonProperty("type")
+    private String type;
+
+    @Schema(example = "SENT", description = "The sending status of the receipt")
+    @JsonProperty("status")
+    private String status;
+
+    @Schema(example = "2024-01-01T12:00:00", description = "The datetime of the last update made on the receipt")
+    @JsonProperty("last_update")
+    private Instant lastUpdate;
+}

--- a/src/main/java/it/gov/pagopa/wispconverter/technicalsupport/controller/model/experimental/monitoring/ReceiptsStatusFilterRequest.java
+++ b/src/main/java/it/gov/pagopa/wispconverter/technicalsupport/controller/model/experimental/monitoring/ReceiptsStatusFilterRequest.java
@@ -1,0 +1,41 @@
+package it.gov.pagopa.wispconverter.technicalsupport.controller.model.experimental.monitoring;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+@Builder
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ReceiptsStatusFilterRequest {
+
+    @Schema(example = "2024-01-01T12:00:00", description = "The lower limit of the date slot in 'Europe/Rome' timezone, used as delimiter for the search time (in yyyy-MM-ddThh:mm:ss)", requiredMode = Schema.RequiredMode.REQUIRED)
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @JsonProperty(value = "lower_bound_date", required = true)
+    private LocalDateTime lowerBoundDate;
+
+    @Schema(example = "2024-01-01T12:00:00", description = "The upper limit of the date slot in 'Europe/Rome' timezone, used as delimiter for the search time (in yyyy-MM-ddThh:mm:ss)", requiredMode = Schema.RequiredMode.REQUIRED)
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @JsonProperty(value = "upper_bound_date", required = true)
+    private LocalDateTime upperBoundDate;
+
+    @Schema(example = "12345678901", description = "The identifier of the creditor institution", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty(value = "creditor_institution", required = true)
+    private String creditorInstitution;
+
+    @Schema(description = "The list of IUV payment codes to be used as a search filter. They can be null if a search on whole creditor institution is required", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty(value = "iuvs")
+    private Set<String> iuvs;
+
+    @Schema(description = "The flag that permits to exclude the receipts in 'SENT' status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty(value = "show_in_sent_status")
+    private boolean showSent;
+}

--- a/src/main/java/it/gov/pagopa/wispconverter/technicalsupport/controller/model/experimental/monitoring/ReceiptsStatusResponse.java
+++ b/src/main/java/it/gov/pagopa/wispconverter/technicalsupport/controller/model/experimental/monitoring/ReceiptsStatusResponse.java
@@ -1,0 +1,31 @@
+package it.gov.pagopa.wispconverter.technicalsupport.controller.model.experimental.monitoring;
+
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ReceiptsStatusResponse {
+
+    @Schema(example = "2024-01-01T12:00:00", description = "The lower limit of the date slot in 'Europe/Rome' timezone, used as delimiter for the search time (in yyyy-MM-ddThh:mm:ss)")
+    @JsonProperty("lower_bound_date")
+    private LocalDateTime lowerBoundDate;
+
+    @Schema(example = "2024-01-01T12:00:00", description = "The upper limit of the date slot in 'Europe/Rome' timezone, used as delimiter for the search time (in yyyy-MM-ddThh:mm:ss)")
+    @JsonProperty("upper_bound_date")
+    private LocalDateTime upperBoundDate;
+
+    @Schema(description = "The receipts explained by their status")
+    @JsonProperty("receipts")
+    private List<ReceiptsStatus> receipts;
+}

--- a/src/main/java/it/gov/pagopa/wispconverter/technicalsupport/repository/RTRepository.java
+++ b/src/main/java/it/gov/pagopa/wispconverter/technicalsupport/repository/RTRepository.java
@@ -24,7 +24,45 @@ public interface RTRepository extends CosmosRepository<RTEntity, String> {
 
     @Query("SELECT * " +
             "FROM c " +
-            "WHERE c._ts*1000 >= DateTimeToTimestamp(@dateFrom) AND c._ts*1000 < DateTimeToTimestamp(@dateTo) " +
+            "WHERE c.rtTimestamp >= DateTimeToTimestamp(@dateFrom) AND c.rtTimestamp < DateTimeToTimestamp(@dateTo) " +
+            "AND c.domainId = @domainId")
+    List<RTEntity> findAllStatus(@Param("dateFrom") String dateFrom,
+                                 @Param("dateTo") String dateTo,
+                                 @Param("domainId") String domainId);
+
+    @Query("SELECT * " +
+            "FROM c " +
+            "WHERE c.rtTimestamp >= DateTimeToTimestamp(@dateFrom) AND c.rtTimestamp < DateTimeToTimestamp(@dateTo) " +
+            "AND c.domainId = @domainId " +
+            "AND c.receiptStatus != 'SENT'")
+    List<RTEntity> findAllStatusExcludingSent(@Param("dateFrom") String dateFrom,
+                                              @Param("dateTo") String dateTo,
+                                              @Param("domainId") String domainId);
+
+    @Query("SELECT * " +
+            "FROM c " +
+            "WHERE c.rtTimestamp >= DateTimeToTimestamp(@dateFrom) AND c.rtTimestamp < DateTimeToTimestamp(@dateTo) " +
+            "AND c.domainId = @domainId " +
+            "AND c.iuv IN (@iuvs)")
+    List<RTEntity> findStatusByIuv(@Param("dateFrom") String dateFrom,
+                                   @Param("dateTo") String dateTo,
+                                   @Param("domainId") String domainId,
+                                   @Param("iuvs") Set<String> iuvs);
+
+    @Query("SELECT * " +
+            "FROM c " +
+            "WHERE c.rtTimestamp >= DateTimeToTimestamp(@dateFrom) AND c.rtTimestamp < DateTimeToTimestamp(@dateTo) " +
+            "AND c.domainId = @domainId " +
+            "AND c.iuv IN (@iuvs) " +
+            "AND c.receiptStatus != 'SENT'")
+    List<RTEntity> findStatusByIuvExcludingSent(@Param("dateFrom") String dateFrom,
+                                                @Param("dateTo") String dateTo,
+                                                @Param("domainId") String domainId,
+                                                @Param("iuvs") Set<String> iuvs);
+
+    @Query("SELECT * " +
+            "FROM c " +
+            "WHERE c.rtTimestamp >= DateTimeToTimestamp(@dateFrom) AND c.rtTimestamp < DateTimeToTimestamp(@dateTo) " +
             "AND c.domainId = @domainId " +
             "AND c.rt = null")
     List<RTEntity> findAllInPendingStatus(@Param("dateFrom") String dateFrom,
@@ -33,7 +71,7 @@ public interface RTRepository extends CosmosRepository<RTEntity, String> {
 
     @Query("SELECT * " +
             "FROM c " +
-            "WHERE c._ts*1000 >= DateTimeToTimestamp(@dateFrom) AND c._ts*1000 < DateTimeToTimestamp(@dateTo) " +
+            "WHERE c.rtTimestamp >= DateTimeToTimestamp(@dateFrom) AND c.rtTimestamp < DateTimeToTimestamp(@dateTo) " +
             "AND c.domainId = @domainId " +
             "AND c.iuv IN (@iuvs) " +
             "AND c.rt = null")

--- a/src/main/java/it/gov/pagopa/wispconverter/technicalsupport/repository/model/RTEntity.java
+++ b/src/main/java/it/gov/pagopa/wispconverter/technicalsupport/repository/model/RTEntity.java
@@ -5,6 +5,8 @@ import com.azure.spring.data.cosmos.core.mapping.PartitionKey;
 import lombok.*;
 import org.springframework.data.annotation.Id;
 
+import java.time.Instant;
+
 @Container(containerName = "receipts-rt")
 @Data
 @ToString(exclude = "rt")
@@ -35,4 +37,10 @@ public class RTEntity {
     private String rt;
 
     private Long rtTimestamp;
+
+    private Instant _ts;
+
+    public Instant getTimestamp() {
+        return this._ts;
+    }
 }

--- a/src/main/java/it/gov/pagopa/wispconverter/technicalsupport/util/Constants.java
+++ b/src/main/java/it/gov/pagopa/wispconverter/technicalsupport/util/Constants.java
@@ -8,7 +8,7 @@ import java.util.Set;
 public class Constants {
 
     public static final String PATTERN_FORMAT = "yyyy-MM-dd";
-    public static final String TIMESTAMP_PATTERN_FORMAT = "yyyy-MM-dd'T'hh:mm:ss";
+    public static final String TIMESTAMP_PATTERN_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
     public static final String HEADER_REQUEST_ID = "X-Request-Id";
 
     public static final String ORGANIZATION = "organizationId";

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,6 +21,7 @@ springdoc.model-and-view-allowed=true
 # Server
 server.servlet.context-path=/
 server.port=8080
+server.shutdown=graceful
 
 # Logging
 logging.level.root=${DEFAULT_LOGGING_LEVEL:INFO}


### PR DESCRIPTION
This PR contains a new API made in order to perform a search on receipts, retrieving their status.

#### List of Changes
 - Add new endpoint for read receipts status

#### Motivation and Context
This feature is required in order to offer an overview about receipts for certain creditor institution

#### How Has This Been Tested?
 - Tested in local pointing towards UAT environment

#### Screenshots (if appropriate):

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
